### PR TITLE
Use relative paths for exclusion matching in weaver.

### DIFF
--- a/src/kilim/analysis/FileLister.java
+++ b/src/kilim/analysis/FileLister.java
@@ -104,10 +104,7 @@ class DirIterator extends FileContainer {
         }
         @Override
         public String getFileName() {
-            try {
-                return file.getCanonicalPath();
-            } catch (IOException ignore) {}
-            return null;
+            return file.getPath();
         }
 
         @Override


### PR DESCRIPTION
Modified DirIterator to return paths relative to the start directory, like JarIterator. This prevents exclusions specified using -x to match agains path components outside the build output directory.

apply https://github.com/kilim/kilim/pull/34 to my fork

